### PR TITLE
FIX+ENH: Gradient coeff + MSMSulc full support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN curl -fsSLO https://repo.continuum.io/miniconda/Miniconda2-4.5.4-Linux-x86_6
     bash Miniconda2-4.5.4-Linux-x86_64.sh -b -p /usr/local/miniconda && \
     rm Miniconda2-4.5.4-Linux-x86_64.sh && \
     conda config --add channels conda-forge && \
-    conda install -y mkl mkl-service numpy nibabel && sync && \
+    conda install -y mkl mkl-service numpy nibabel pandas && sync && \
     conda clean -tipsy && sync && \
     pip install --no-cache-dir pybids==0.6.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,41 @@
-# Use Ubuntu 14.04 LTS
-FROM ubuntu:trusty-20170119
+# Use Jessie for correct perl version
+# https://mail.nmr.mgh.harvard.edu/pipermail/freesurfer/2016-May/045407.html
+FROM neurodebian:jessie-non-free
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV LANG="C.UTF-8" \
+    LC_ALL="C.UTF-8"
 
 # Download FreeSurfer
-RUN apt-get -y update \
-    && apt-get install -y wget && \
-    wget -qO- ftp://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/5.3.0-HCP/freesurfer-Linux-centos4_x86_64-stable-pub-v5.3.0-HCP.tar.gz | tar zxv -C /opt \
-    --exclude='freesurfer/trctrain' \
-    --exclude='freesurfer/subjects/fsaverage_sym' \
-    --exclude='freesurfer/subjects/fsaverage3' \
-    --exclude='freesurfer/subjects/fsaverage4' \
-    --exclude='freesurfer/subjects/fsaverage5' \
-    --exclude='freesurfer/subjects/fsaverage6' \
-    --exclude='freesurfer/subjects/cvs_avg35' \
-    --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
-    --exclude='freesurfer/subjects/bert' \
-    --exclude='freesurfer/subjects/V1_average' \
-    --exclude='freesurfer/average/mult-comp-cor' \
-    --exclude='freesurfer/lib/cuda' \
-    --exclude='freesurfer/lib/qt' && \
-    apt-get install -y tcsh bc tar libgomp1 perl-modules curl
+RUN apt-get -qq update && \
+    apt-get install -yq --no-install-recommends \
+      bc \
+      bzip2 \
+      ca-certificates \
+      curl \
+      libgomp1 \
+      perl-modules \
+      tar \
+      tcsh \
+      wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    wget -qO- ftp://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/5.3.0-HCP/freesurfer-Linux-centos4_x86_64-stable-pub-v5.3.0-HCP.tar.gz \
+    | tar zxv -C /opt \
+      --exclude='freesurfer/trctrain' \
+      --exclude='freesurfer/subjects/fsaverage_sym' \
+      --exclude='freesurfer/subjects/fsaverage3' \
+      --exclude='freesurfer/subjects/fsaverage4' \
+      --exclude='freesurfer/subjects/fsaverage5' \
+      --exclude='freesurfer/subjects/fsaverage6' \
+      --exclude='freesurfer/subjects/cvs_avg35' \
+      --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
+      --exclude='freesurfer/subjects/bert' \
+      --exclude='freesurfer/subjects/V1_average' \
+      --exclude='freesurfer/average/mult-comp-cor' \
+      --exclude='freesurfer/lib/cuda' \
+      --exclude='freesurfer/lib/qt' && \
+    echo "cHJpbnRmICJrcnp5c3p0b2YuZ29yZ29sZXdza2lAZ21haWwuY29tXG41MTcyXG4gKkN2dW12RVYzelRmZ1xuRlM1Si8yYzFhZ2c0RVxuIiA+IC9vcHQvZnJlZXN1cmZlci9saWNlbnNlLnR4dAo=" | base64 -d | sh
 
 # Set up the environment
 ENV OS=Linux \
@@ -36,81 +53,55 @@ ENV OS=Linux \
     FMRI_ANALYSIS_DIR=/opt/freesurfer/fsfast \
     PERL5LIB=/opt/freesurfer/mni/lib/perl5/5.8.5 \
     MNI_PERL5LIB=/opt/freesurfer/mni/lib/perl5/5.8.5 \
-    PATH=/opt/freesurfer/bin:/opt/freesurfer/fsfast/bin:/opt/freesurfer/tktools:/opt/freesurfer/mni/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
+    PATH=/opt/freesurfer/bin:/opt/freesurfer/fsfast/bin:/opt/freesurfer/tktools:/opt/freesurfer/mni/bin:$PATH
 
+# Install MCR 2016b
+ENV MATLABCMD="/opt/matlabmcr-2016b/v91/toolbox/matlab" \
+    MATLAB_COMPILER_RUNTIME="/opt/matlabmcr-2016b/v91" \
+    LD_LIBRARY_PATH="/opt/matlabmcr-2016b/v91/runtime/glnxa64:/opt/matlabmcr-2016b/v91/bin/glnxa64:/opt/matlabmcr-2016b/v91/sys/os/glnxa64:$LD_LIBRARY_PATH"
 
-# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
-RUN set -x \
-	&& apt-get update \
-	&& { \
-		which gpg \
-		|| apt-get install -y --no-install-recommends gnupg \
-	; } \
-# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
-# so, if we're not running gnupg 1.x, explicitly install dirmngr too
-	&& { \
-		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
-		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq \
+    && apt-get install -y -q --no-install-recommends \
+       libxext6 \
+       libxpm-dev \
+       libxt6 \
+       unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && echo "Downloading MATLAB Compiler Runtime ..." \
+    && curl -fsSL --retry 5 -o /tmp/mcr.zip https://ssd.mathworks.com/supportfiles/downloads/R2016b/deployment_files/R2016b/installers/glnxa64/MCR_R2016b_glnxa64_installer.zip \
+    && unzip -q /tmp/mcr.zip -d /tmp/mcrtmp \
+    && /tmp/mcrtmp/install -destinationFolder /opt/matlabmcr-2016b -mode silent -agreeToLicense yes \
+    && rm -rf /tmp/*
 
-# apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
-# this makes "apt-key list" output prettier too!
-RUN set -x \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
-	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -rf "$GNUPGHOME" \
-	&& apt-key list | grep neurodebian
+# Install miniconda2
+ENV PATH="/usr/local/miniconda/bin:$PATH"
+RUN curl -fsSLO https://repo.continuum.io/miniconda/Miniconda2-4.5.4-Linux-x86_64.sh && \
+    bash Miniconda2-4.5.4-Linux-x86_64.sh -b -p /usr/local/miniconda && \
+    rm Miniconda2-4.5.4-Linux-x86_64.sh && \
+    conda config --add channels conda-forge && \
+    conda install -y mkl mkl-service numpy nibabel && sync && \
+    conda clean -tipsy && sync && \
+    pip install --no-cache-dir pybids==0.5.1
 
-RUN { \
-	echo 'deb http://neuro.debian.net/debian trusty main'; \
-	echo 'deb http://neuro.debian.net/debian data main'; \
-	echo '#deb-src http://neuro.debian.net/debian-devel trusty main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
-
-RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list
-    
-# Install FSL 5.0.9
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -sSL http://neuro.debian.net/lists/trusty.us-ca.full >> /etc/apt/sources.list.d/neurodebian.sources.list && \
-    apt-key adv --recv-keys --keyserver hkp://pgp.mit.edu:80 0xA5D32F012649A5A9 && \
-    apt-get update && \
-    apt-get install -y fsl-core=5.0.9-4~nd14.04+1
-
-# Configure environment
-ENV FSLDIR=/usr/share/fsl/5.0
-ENV FSL_DIR="${FSLDIR}" \
-    FSLOUTPUTTYPE=NIFTI_GZ \
-    PATH=/usr/lib/fsl/5.0:$PATH \
-    FSLMULTIFILEQUIT=TRUE \
-    POSSUMDIR=/usr/share/fsl/5.0 \
-    LD_LIBRARY_PATH=/usr/lib/fsl/5.0:$LD_LIBRARY_PATH \
-    FSLTCLSH=/usr/bin/tclsh \
-    FSLWISH=/usr/bin/wish \
-    FSLOUTPUTTYPE=NIFTI_GZ
-
-RUN echo "cHJpbnRmICJrcnp5c3p0b2YuZ29yZ29sZXdza2lAZ21haWwuY29tXG41MTcyXG4gKkN2dW12RVYzelRmZ1xuRlM1Si8yYzFhZ2c0RVxuIiA+IC9vcHQvZnJlZXN1cmZlci9saWNlbnNlLnR4dAo=" | base64 -d | sh
-
-# Install Connectome Workbench
-RUN apt-get update && apt-get -y install connectome-workbench=1.2.3-1~nd14.04+1
-
-ENV CARET7DIR=/usr/bin
+# Install connectome-workbench
+WORKDIR /opt
+RUN wget -q https://ftp.humanconnectome.org/workbench/workbench-linux64-v1.3.0.zip -O wb.zip \
+    && unzip wb.zip \
+    && rm wb.zip
+ENV CARET7DIR="/opt/workbench/bin_linux64"
 
 # Install HCP Pipelines and MSM binaries
-WORKDIR /opt
-RUN apt-get -y update \
-    && apt-get install -y --no-install-recommends python-numpy && \
-    wget -q https://github.com/Washington-University/Pipelines/archive/v3.17.0.tar.gz -O pipelines.tar.gz && \
-    tar zxf pipelines.tar.gz && \
-    mv /opt/Pipelines-* /opt/HCP-Pipelines && \
-    rm pipelines.tar.gz && \
-    wget -q https://www.doc.ic.ac.uk/~ecr05/MSM_HOCR_v1/MSM_HOCR_v1-download.tgz -O MSMs.tar.gz && \
-    tar zxf MSMs.tar.gz && \
-    rm MSMs.tar.gz && \
-    mv MSM_HOCR_v1/Ubuntu /opt/HCP-Pipelines/MSMBinaries && \
-    rm -rf MSM_HOCR_v1
+RUN apt-get -qq update && \
+    apt-get install -yq --no-install-recommends gcc g++ libglu1 && \
+    rm -rf /tmp/* && \
+    wget -qO- https://github.com/Washington-University/Pipelines/archive/v3.26.1.tar.gz | tar xz -C /tmp && \
+    mv /tmp/* /opt/HCP-Pipelines && \
+    rm -rf /tmp/* && \
+    wget -qO- https://www.doc.ic.ac.uk/~ecr05/MSM_HOCR_v2/MSM_HOCR_v2-download.tgz | tar xz -C /tmp && \
+    mv /tmp/homes/ecr05/MSM_HOCR_v2/Ubuntu /opt/HCP-Pipelines/MSMBinaries && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /
 
@@ -128,23 +119,48 @@ ENV HCPPIPEDIR_Templates=${HCPPIPEDIR}/global/templates \
     HCPPIPEDIR_dMRITract=${HCPPIPEDIR}/DiffusionTractography/scripts \
     HCPPIPEDIR_Global=${HCPPIPEDIR}/global/scripts \
     HCPPIPEDIR_tfMRIAnalysis=${HCPPIPEDIR}/TaskfMRIAnalysis/scripts \
-    MSMBin=${HCPPIPEDIR}/MSMBinaries
+    MSMBINDIR=${HCPPIPEDIR}/MSMBinaries \
+    MSMCONFIGDIR=${HCPPIPEDIR}/MSMConfig
 
 ## Install the validator
+RUN wget -qO- https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    npm install -g bids-validator@0.26.13 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install FSL 5.0.9 now to ensure it is not removed
 RUN apt-get update && \
-    apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get remove -y curl && \
-    apt-get install -y nodejs
+    apt-get install -y fsl=5.0.9-4~nd80+1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN npm install -g bids-validator@0.26.11
+# Configure environment
+ENV FSLDIR=/usr/share/fsl/5.0
+ENV FSL_DIR="${FSLDIR}" \
+    FSLOUTPUTTYPE=NIFTI_GZ \
+    PATH=/usr/lib/fsl/5.0:$PATH \
+    FSLMULTIFILEQUIT=TRUE \
+    POSSUMDIR=/usr/share/fsl/5.0 \
+    LD_LIBRARY_PATH=/usr/lib/fsl/5.0:$LD_LIBRARY_PATH \
+    FSLTCLSH=/usr/bin/tclsh \
+    FSLWISH=/usr/bin/wish \
+    FSLOUTPUTTYPE=NIFTI_GZ
 
-RUN apt-get update && apt-get install -y --no-install-recommends python-pip python-six python-nibabel python-setuptools
-RUN pip install pybids==0.5.1
-ENV PYTHONPATH=""
+# upgrade our libstdc++
+RUN echo "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y libstdc++6
 
-COPY run.py /run.py
+# overwrite matlab mcr shared object
+RUN rm /opt/matlabmcr-2016b/v91/sys/os/glnxa64/libstdc++.so.6 && \
+    ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /opt/matlabmcr-2016b/v91/sys/os/glnxa64/libstdc++.so.6
+
+# install gradient_unwarp.py (v1.0.3)
+RUN pip install https://github.com/Washington-University/gradunwarp/archive/v1.0.3.zip
+
+COPY run.py version /
 RUN chmod +x /run.py
 
-COPY version /version
 ENTRYPOINT ["/run.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN curl -fsSLO https://repo.continuum.io/miniconda/Miniconda2-4.5.4-Linux-x86_6
     conda config --add channels conda-forge && \
     conda install -y mkl mkl-service numpy nibabel && sync && \
     conda clean -tipsy && sync && \
-    pip install --no-cache-dir pybids==0.5.1
+    pip install --no-cache-dir pybids==0.6.3
 
 # Install connectome-workbench
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN curl -fsSLO https://repo.continuum.io/miniconda/Miniconda2-4.5.4-Linux-x86_6
     conda config --add channels conda-forge && \
     conda install -y mkl mkl-service numpy nibabel pandas && sync && \
     conda clean -tipsy && sync && \
-    pip install --no-cache-dir pybids==0.6.3
+    pip install --no-cache-dir pybids[analysis]==0.6.3
 
 # Install connectome-workbench
 WORKDIR /opt

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - "~/data"
 
   override:
-    - if [[ ! -d ~/data/hcp_example_bids ]]; then wget -c -O ${HOME}/hcp_example_bids.zip "https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/5a8efffe91b689000c9f5ce5" && mkdir -p ${HOME}/data && unzip ${HOME}/hcp_example_bids.zip -d ${HOME}/data; fi
+    - if [[ ! -d ~/data/hcp_example_bids_v3 ]]; then wget -c -O ${HOME}/hcp_example_bids.zip "https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/5a8efffe91b689000c9f5ce5" && mkdir -p ${HOME}/data && unzip ${HOME}/hcp_example_bids.zip -d ${HOME}/data; fi
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
     - git describe --tags > version
     - docker build -t bids/${CIRCLE_PROJECT_REPONAME,,} . :

--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/local/miniconda/bin/python
+
 from __future__ import print_function
 import argparse
 import os
@@ -62,7 +63,7 @@ def run_pre_freesurfer(**args):
     '--t1samplespacing="{t1samplespacing}" ' + \
     '--t2samplespacing="{t2samplespacing}" ' + \
     '--unwarpdir="{unwarpdir}" ' + \
-    '--gdcoeffs="NONE" ' + \
+    '--gdcoeffs={gdcoeffs} ' + \
     '--avgrdcmethod={avgrdcmethod} ' + \
     '--topupconfig="{HCPPIPEDIR_Config}/b02b0.cnf" ' + \
     '--printcom=""'
@@ -130,7 +131,7 @@ def run_generic_fMRI_volume_processsing(**args):
       '--unwarpdir={unwarpdir} ' + \
       '--fmrires={fmrires:s} ' + \
       '--dcmethod={dcmethod} ' + \
-      '--gdcoeffs="NONE" ' + \
+      '--gdcoeffs={gdcoeffs} ' + \
       '--topupconfig={HCPPIPEDIR_Config}/b02b0.cnf ' + \
       '--printcom="" ' + \
       '--biascorrection={biascorrection} ' + \
@@ -161,7 +162,7 @@ def run_diffusion_processsing(**args):
       '--subject="{subject}" ' + \
       '--echospacing="{echospacing}" '+ \
       '--PEdir={PEdir} ' + \
-      '--gdcoeffs="NONE" ' + \
+      '--gdcoeffs={gdcoeffs} ' + \
       '--printcom=""'
     cmd = cmd.format(**args)
     run(cmd, cwd=args["path"], env={"OMP_NUM_THREADS": str(args["n_cpus"])})
@@ -196,6 +197,8 @@ parser.add_argument('--stages', help='Which stages to run. Space separated list.
                             'DiffusionPreprocessing'])
 parser.add_argument('--coreg', help='Coregistration method to use',
                     choices=['MSMSulc', 'FS'], default='MSMSulc')
+parser.add_argument('--gdcoeffs', help='Gradients coefficients file',
+                    default="NONE")
 parser.add_argument('--license_key', help='FreeSurfer license key - letters and numbers after "*" in the email you received after registration. To register (for free) visit https://surfer.nmr.mgh.harvard.edu/registration.html',
                     required=True)
 parser.add_argument('-v', '--version', action='version',
@@ -325,6 +328,7 @@ if args.analysis_level == "participant":
                                                 n_cpus=args.n_cpus,
                                                 t1_template_res=t1_template_res,
                                                 t2_template_res=t2_template_res,
+                                                gdcoeffs=args.gdcoeffs,
                                                 **fmap_args)),
                        ("FreeSurfer", partial(run_freesurfer,
                                              path=args.output_dir,
@@ -398,7 +402,8 @@ if args.analysis_level == "participant":
                                                       fmrires=fmrires,
                                                       dcmethod=dcmethod,
                                                       biascorrection=biascorrection,
-                                                      n_cpus=args.n_cpus)),
+                                                      n_cpus=args.n_cpus,
+                                                      gdcoeffs=args.gdcoeffs)),
                                 ("fMRISurface", partial(run_generic_fMRI_surface_processsing,
                                                        path=args.output_dir,
                                                        subject="sub-%s"%subject_label,

--- a/run.py
+++ b/run.py
@@ -364,9 +364,9 @@ if args.analysis_level == "participant":
                 for fieldmap in fieldmap_set:
                     enc_dir = layout.get_metadata(fieldmap["epi"])["PhaseEncodingDirection"]
                     if "-" in enc_dir:
-                        SEPhaseNeg = fieldmap
+                        SEPhaseNeg = fieldmap['epi']
                     else:
-                        SEPhasePos = fieldmap
+                        SEPhasePos = fieldmap['epi']
                 echospacing = layout.get_metadata(fmritcs)["EffectiveEchoSpacing"]
                 unwarpdir = layout.get_metadata(fmritcs)["PhaseEncodingDirection"]
                 unwarpdir = unwarpdir.replace("i","x").replace("j", "y").replace("k", "z")


### PR DESCRIPTION
Changes
- `Dockerfile`
  - change OS to jessie (stretch's `perl` incompatible with FS5.3)
  - include `gradunwarp` and later version of `libstdc++6` (needed for MSMSulc)
  - recipe cleanup
- `run.py`
  - new option for scanner gradients coeff file (for image unwarping)
  - properly extract BOLD fieldmap phase encodings